### PR TITLE
Allow for regex to be used for the keys in embeddedObjKeys map

### DIFF
--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -115,7 +115,7 @@ const compareObject = (oldObj: any, newObj: any, path: any, embeddedObjKeys: any
 };
 
 const compareArray = (oldObj: any, newObj: any, path: any, embeddedObjKeys: any, keyPath: any) => {
-  const left = embeddedObjKeys != null ? embeddedObjKeys[keyPath.join('.')] : undefined;
+  const left = getObjectKey(embeddedObjKeys, keyPath);
   const uniqKey = left != null ? left : '$index';
   const indexedOldObj = convertArrayToObj(oldObj, uniqKey);
   const indexedNewObj = convertArrayToObj(newObj, uniqKey);
@@ -132,6 +132,22 @@ const compareArray = (oldObj: any, newObj: any, path: any, embeddedObjKeys: any,
   } else {
     return [];
   }
+};
+
+const getObjectKey = (embeddedObjKeys: any, keyPath: any) => {
+  if (embeddedObjKeys != null) {
+    const path = keyPath.join('.');
+    const key = embeddedObjKeys[path];
+    if (key != null) {
+      return key;
+    }
+    for (const regex in embeddedObjKeys) {
+      if (path.match(new RegExp(regex))) {
+        return embeddedObjKeys[regex];
+      }
+    }
+  }
+  return undefined;
 };
 
 const convertArrayToObj = (arr: any[], uniqKey: any) => {

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -324,6 +324,15 @@ import {
       expect(diffs).toMatchObject(changeset)
       done()
     })
+
+    test('should return correct diff for object with embedded array object that does have regex key', done => {
+      const diffs = diff(oldObj, newObj, {
+        '^children$': 'name',
+        '^[\\w+\.]+subset$': 'id',
+      })
+      expect(diffs).toMatchObject(changeset)
+      done()
+    })
   })
   
   describe('jsonDiff#applyChangeset', () => {


### PR DESCRIPTION
This change would allow for easily specifying keys for any depth of the hierarchy.
For example, for a family tree, a single entry will be enough: `^[\\w\.]+children$': 'name'`
This basically indicates that for `children` array at any level of the hierarchy `name` is the key property.
It also does not affect existing functionality (lookup of a key in the map) - lines 140-143 guarantee that.