### PR TITLE
Correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If a key is specified for an embedded array, the diff will be generated based on
 
 ```javascript
 
-  var changesets = require('diff-json-ts');
+  var changesets = require('json-diff-ts');
   var newObj, oldObj;
 
   oldObj = {
@@ -133,7 +133,7 @@ The **flatChange** format will look like this:
 
 ```javascript
 
-  var changesets = require('diff-json-ts');
+  var changesets = require('json-diff-ts');
   var oldObj = {
     name: 'joe',
     age: 55,
@@ -192,7 +192,7 @@ The **flatChange** format will look like this:
 
 ```javascript
 
-  var changesets = require('diff-json-ts');
+  var changesets = require('json-diff-ts');
 
   var newObj = {
     name: 'smith',


### PR DESCRIPTION
Update examples: **s/diff-json-ts/json-diff-ts/**

Should also update the github description to link to this package on npmjs instead of: 
![image](https://user-images.githubusercontent.com/1915543/128941452-6173e50a-e6d9-41c8-96d7-aafcc0ebd114.png)
