### PR TITLE
enable to use functions that return an object key

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ If a key is specified for an embedded array, the diff will be generated based on
 
 
   // Assume children is an array of child object and the child object has 'name' as its primary key
-  diffs = changesets.diff(oldObj, newObj, {children: 'name'}); // keys can also be hierarchical e.g. {children: 'name', 'children.grandChildren', 'age'}
+  // keys can also be hierarchical e.g. {children: 'name', 'children.grandChildren', 'age'}
+  // or use functions that return the key of an object e.g. {children: function(obj) { return obj.name; }}
+  diffs = changesets.diff(oldObj, newObj, {children: 'name'});
 
   expect(diffs).to.eql([
     {

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -296,7 +296,7 @@ const revertBranchChange = (obj: any, change: any) => {
   }
 };
 
-export const diff = (oldObj: any, newObj: any, embeddedObjKeys?: Dictionary<string>): IChange[] =>
+export const diff = (oldObj: any, newObj: any, embeddedObjKeys?: Dictionary<string | Function>): IChange[] =>
   compare(oldObj, newObj, [], embeddedObjKeys, []);
 
 export const applyChangeset = (obj: any, changeset: Changeset) => {
@@ -331,7 +331,7 @@ export enum Operation {
 export interface IChange {
   type: Operation;
   key: string;
-  embeddedKey?: string;
+  embeddedKey?: string | Function;
   value?: any | any[];
   oldValue?: any;
   changes?: IChange[];
@@ -347,7 +347,7 @@ export interface IFlatChange {
   oldValue?: any;
 }
 
-export const flattenChangeset = (obj: Changeset | IChange, path = '$', embeddedKey?: string): IFlatChange[] => {
+export const flattenChangeset = (obj: Changeset | IChange, path = '$', embeddedKey?: string | Function): IFlatChange[] => {
   if (Array.isArray(obj)) {
     return obj.reduce((memo, change) => [...memo, ...flattenChangeset(change, path, embeddedKey)], [] as IFlatChange[]);
   } else {

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -13,6 +13,7 @@ import {
   let changesetWithoutEmbeddedKey: IChange[]
   let changeset: IChange[]
   let changesetWithDoubleRemove: IChange[]
+  let changesetWithFunctionKey: IChange[]
   
   beforeEach(done => {
     oldObj = {
@@ -302,7 +303,88 @@ import {
           { type: Operation.ADD, key: '2', value: { name: 'kid2', age: 2 } },
         ],
       },
-  
+
+      { type: Operation.REMOVE, key: 'age', value: 55 },
+      { type: Operation.REMOVE, key: 'empty', value: undefined },
+    ]
+
+    changesetWithFunctionKey = [
+      { type: Operation.UPDATE, key: 'name', value: 'smith', oldValue: 'joe' },
+      { type: Operation.REMOVE, key: 'mixed', value: 10 },
+      { type: Operation.ADD, key: 'mixed', value: '10' },
+      {
+        type: Operation.UPDATE,
+        key: 'nested',
+        changes: [
+          { type: Operation.UPDATE, key: 'inner', value: 2, oldValue: 1 },
+        ],
+      },
+      { type: Operation.UPDATE, key: 'date', value: new Date('October 12, 2014 11:13:00'), oldValue:  new Date('October 13, 2014 11:13:00') },
+      {
+        type: Operation.UPDATE,
+        key: 'coins',
+        embeddedKey: '$index',
+        changes: [{ type: Operation.ADD, key: '2', value: 1 }],
+      },
+      {
+        type: Operation.UPDATE,
+        key: 'toys',
+        embeddedKey: '$index',
+        changes: [
+          { type: Operation.REMOVE, key: '0', value: 'car' },
+          { type: Operation.REMOVE, key: '1', value: 'doll' },
+          { type: Operation.REMOVE, key: '2', value: 'car' },
+        ],
+      },
+      {
+        type: Operation.UPDATE,
+        key: 'pets',
+        embeddedKey: '$index',
+        changes: [
+          { type: Operation.REMOVE, key: '0', value: undefined },
+          { type: Operation.REMOVE, key: '1', value: null },
+        ],
+      },
+      {
+        type: Operation.UPDATE,
+        key: 'children',
+        embeddedKey: expect.any(Function),
+        changes: [
+          {
+            type: Operation.UPDATE,
+            key: 'kid1',
+            changes: [
+              { type: Operation.UPDATE, key: 'age', value: 0, oldValue: 1 },
+              {
+                type: Operation.UPDATE,
+                key: 'subset',
+                embeddedKey: expect.any(Function),
+                changes: [
+                  {
+                    type: Operation.UPDATE,
+                    key: '1',
+                    changes: [
+                      {
+                        type: Operation.UPDATE,
+                        key: 'value',
+                        value: 'heihei',
+                        oldValue: 'haha',
+                      },
+                    ],
+                  },
+                  {
+                    type: Operation.REMOVE,
+                    key: '2',
+                    value: { id: 2, value: 'hehe' },
+                  },
+                ],
+              },
+            ],
+          },
+          { type: Operation.ADD, key: 'kid3', value: { name: 'kid3', age: 3 } },
+        ],
+      },
+
       { type: Operation.REMOVE, key: 'age', value: 55 },
       { type: Operation.REMOVE, key: 'empty', value: undefined },
     ]
@@ -331,6 +413,15 @@ import {
         '^[\\w+\.]+subset$': 'id',
       })
       expect(diffs).toMatchObject(changeset)
+      done()
+    })
+
+    test('should return correct diff for object with embedded array object that does have function key', done => {
+      const diffs = diff(oldObj, newObj, {
+        children: function(obj: { name: string }){ return obj.name },
+        'children.subset': function(obj: { id: number }){ return obj.id },
+      })
+      expect(diffs).toMatchObject(changesetWithFunctionKey)
       done()
     })
   })


### PR DESCRIPTION
This is required for objects with a multi-property primary/natural key.

Closes #27