### PR TITLE
improve handling of JSON Path segments that include periods

### DIFF
--- a/tests/flattenChangeset.test.ts
+++ b/tests/flattenChangeset.test.ts
@@ -1,0 +1,40 @@
+import { diff, flattenChangeset } from '../src/jsonDiff';
+
+describe('flattenChangeset', () => {
+  test('when JSON path segements contain periods', (done) => {
+    const oldObject = { 'a.b': 1 };
+    const newObject = { 'a.b': 2 };
+
+    const actual = flattenChangeset(diff(oldObject, newObject))[0];
+
+    console.log(JSON.stringify(actual.path));
+    expect(actual.path).toBe('$[a.b]');
+    done();
+  });
+
+  test('when JSON path segments containing periods use embedded keys', (done) => {
+    const oldObject = { 'a.b': [{ c: 1 }] };
+    const newObject = { 'a.b': [{ c: 2 }] };
+    const diffs = diff(oldObject, newObject, { 'a.b': 'c' });
+
+    const actual = flattenChangeset(diffs);
+
+    expect(actual.length).toBe(2);
+    expect(actual[0].path).toBe('$[a.b]');
+    expect(actual[1].path).toBe("$[a.b][?(@.c='1')]");
+    done();
+  });
+
+  test('when embedded key name contains periods', (done) => {
+    const oldObject = { a: [{ b: 1, 'c.d': 10 }] };
+    const newObject = { a: [{ b: 2, 'c.d': 20 }] };
+    const diffs = diff(oldObject, newObject, { a: 'c.d' });
+
+    const actual = flattenChangeset(diffs);
+
+    expect(actual.length).toBe(2);
+    expect(actual[0].path).toBe('$.a');
+    expect(actual[1].path).toBe("$.a[?(@[c.d]='10')]");
+    done();
+  });
+});


### PR DESCRIPTION
## Goal

This PR attempts to improve the produced JSON paths when segments of the path include periods (`.`).

## Context

Stoplight.io has been using json-diff-ts as a test tool, and it's been working great!  Thank you!  

Because we're using it on OpenAPI documents, we often see periods (`.`) included in either API paths (e.g., [/account/settings.json](https://github.com/APIs-guru/openapi-directory/blob/main/APIs/twitter.com/legacy/1.1/swagger.yaml#L33)), in schema names, etc.  We primarily use the "flattened" changeset format, which includes a JSON Path that refers to the change.  When a period is included, the paths aren't quite as we'd expect them to be.

Using the previous example of a path that includes a period described by `flattenChangeset()`...
- expected: `$.paths[/account/settings.json].get`
- actual: `$.paths./account/settings.json.get`

I know that there are many other cases here I haven't covered, such as when the segment also includes open-square-bracket (`[`), but I hope this will be a minor improvement anyway.  Please let me know if there's anything you'd like to see changed to incorporate this.