### PR TITLE
Update unflattenChanges regex 

### DIFF
--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -193,7 +193,7 @@ export const unflattenChanges = (changes: IFlatChange | IFlatChange[]) => {
     const obj = {} as IChange;
     let ptr = obj;
 
-    const segments = change.path.split(/(?<=[^@])\.(?=[^@])/);
+    const segments = change.path.split(/\.(?=[^\]]*(?:\[|$))/);
 
     if (segments.length === 1) {
       ptr.key = change.key;

--- a/tests/unflattenChanges.test.ts
+++ b/tests/unflattenChanges.test.ts
@@ -1,0 +1,63 @@
+import { diff, flattenChangeset, unflattenChanges } from '../src/jsonDiff';
+
+describe('unflattenChanges', () => {
+  
+  test('when using an embedded key on diff', (done) => {
+
+    const oldData = {
+      characters: [
+        { id: 'LUK', name: 'Luke Skywalker' },
+        { id: 'LEI', name: 'Leia Organa' }
+      ]
+    };
+    
+    const newData = {
+      characters: [
+        { id: 'LUK', name: 'Luke' },
+        { id: 'LEI', name: 'Leia Organa' }
+      ]
+    };
+
+    const actual = flattenChangeset(diff(oldData, newData, { characters: 'id' }))[0];
+    expect(actual.path).toBe(`$.characters[?(@.id=='LUK')].name`);
+    const unflattened = unflattenChanges(actual);
+
+
+    expect(unflattened[0].key).toBe('characters')
+    expect(unflattened[0].changes?.[0]?.key).toBe('LUK')
+
+    done();
+  });
+
+  test('when using an embedded key on diff and data key has periods', (done) => {
+
+    const oldData = {
+      characters: [
+        { id: 'LUK.A', name: 'Luke Skywalker' },
+        { id: 'LEI.B', name: 'Leia Organa' }
+      ]
+    };
+    
+    const newData = {
+      characters: [
+        { id: 'LUK.A', name: 'Luke' },
+        { id: 'LEI.B', name: 'Leia Organa' }
+      ]
+    };
+
+    const difference = diff(oldData, newData, { characters: 'id' })
+
+    const actual = flattenChangeset(difference)[0];
+    expect(actual.path).toBe(`$.characters[?(@.id=='LUK.A')].name`);
+
+    console.log('actual', actual)
+
+    const unflattened = unflattenChanges(actual);
+
+    expect(unflattened[0].key).toBe('characters')
+    expect(unflattened[0].changes?.[0]?.key).toBe('LUK.A')
+
+    done();
+  });
+
+});


### PR DESCRIPTION
Meant to address this issue I made yesterday: https://github.com/ltwlf/json-diff-ts/issues/133

I replaced the split regex with the regex found here: https://stackoverflow.com/questions/732029/how-to-split-string-by-unless-is-within-brackets-using-regex , replacing the comma with a period, and added a couple tests