### PR TITLE
Fix issues when old value is array

### DIFF
--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -349,7 +349,17 @@ const compare = (oldObj: any, newObj: any, path: any, keyPath: any, options: Opt
   // `treatTypeChangeAsReplace` is a flag used to determine if a change in type should be treated as a replacement.
   if (options.treatTypeChangeAsReplace && typeOfOldObj !== typeOfNewObj) {
     changes.push({ type: Operation.REMOVE, key: getKey(path), value: oldObj });
-    changes.push({ type: Operation.ADD, key: getKey(path), value: newObj });
+
+    // As undefined is not serialized into JSON, it should not count as an added value.
+    if (typeOfNewObj !== 'undefined') {
+      changes.push({ type: Operation.ADD, key: getKey(path), value: newObj });
+    }
+
+    return changes;
+  }
+
+  if (typeOfNewObj === 'undefined' && typeOfOldObj !== 'undefined') {
+    changes.push({ type: Operation.REMOVE, key: getKey(path), value: oldObj });
     return changes;
   }
 
@@ -458,6 +468,10 @@ const compareArray = (
   keyPath: any,
   options: Options
 ) => {
+  if (getTypeOfObj(newObj) !== 'Array') {
+    return [{ type: Operation.UPDATE, key: getKey(path), value: newObj, oldValue: oldObj }];
+  }
+
   const left = getObjectKey(options.embeddedObjKeys, keyPath);
   const uniqKey = left != null ? left : '$index';
   const indexedOldObj = convertArrayToObj(oldObj, uniqKey);

--- a/tests/__fixtures__/jsonDiff.fixture.ts
+++ b/tests/__fixtures__/jsonDiff.fixture.ts
@@ -308,3 +308,53 @@ export const changesetWithoutEmbeddedKey: IChange[] = [
   { type: Operation.REMOVE, key: 'age', value: 55 },
   { type: Operation.REMOVE, key: 'empty', value: undefined }
 ];
+
+export const assortedDiffs: {
+  oldVal: unknown;
+  newVal: unknown;
+  expectedReplacement: IChange[];
+  expectedUpdate: IChange[];
+}[] = [
+  {
+    oldVal: 1,
+    newVal: 'a',
+    expectedReplacement: [
+      { type: Operation.REMOVE, key: '$root', value: 1 },
+      { type: Operation.ADD, key: '$root', value: 'a' }
+    ],
+    expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: 'a', oldValue: 1 }]
+  },
+  {
+    oldVal: [],
+    newVal: null,
+    expectedReplacement: [
+      { type: Operation.REMOVE, key: '$root', value: [] },
+      { type: Operation.ADD, key: '$root', value: null }
+    ],
+    expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: null, oldValue: [] }]
+  },
+  {
+    oldVal: [],
+    newVal: undefined,
+    expectedReplacement: [{ type: Operation.REMOVE, key: '$root', value: [] }],
+    expectedUpdate: [{ type: Operation.REMOVE, key: '$root', value: [] }]
+  },
+  {
+    oldVal: [],
+    newVal: 0,
+    expectedReplacement: [
+      { type: Operation.REMOVE, key: '$root', value: [] },
+      { type: Operation.ADD, key: '$root', value: 0 }
+    ],
+    expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: 0, oldValue: [] }]
+  },
+  {
+    oldVal: [],
+    newVal: 1,
+    expectedReplacement: [
+      { type: Operation.REMOVE, key: '$root', value: [] },
+      { type: Operation.ADD, key: '$root', value: 1 }
+    ],
+    expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: 1, oldValue: [] }]
+  },
+];

--- a/tests/__snapshots__/jsonDiff.test.ts.snap
+++ b/tests/__snapshots__/jsonDiff.test.ts.snap
@@ -845,7 +845,7 @@ exports[`jsonDiff#valueKey apply array value keys 1`] = `
 }
 `;
 
-exports[`jsonDiff#valueKey corretly flatten array value keys 1`] = `
+exports[`jsonDiff#valueKey correctly flatten array value keys 1`] = `
 [
   {
     "key": "lemon",
@@ -871,7 +871,7 @@ exports[`jsonDiff#valueKey corretly flatten array value keys 1`] = `
 ]
 `;
 
-exports[`jsonDiff#valueKey corretly unflatten array value keys 1`] = `
+exports[`jsonDiff#valueKey correctly unflatten array value keys 1`] = `
 [
   {
     "changes": [

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -61,6 +61,14 @@ describe('jsonDiff#diff', () => {
     const diffs = diff(oldObj, newObj, { keysToSkip: [keyToSkip] });
     expect(diffs).toMatchSnapshot();
   });
+
+  it.each(fixtures.assortedDiffs)(
+    'correctly diffs $oldVal with $newVal',
+    ({ oldVal, newVal, expectedReplacement, expectedUpdate }) => {
+      expect(diff(oldVal, newVal, { treatTypeChangeAsReplace: true })).toEqual(expectedReplacement);
+      expect(diff(oldVal, newVal, { treatTypeChangeAsReplace: false })).toEqual(expectedUpdate);
+    }
+  );
 });
 
 describe('jsonDiff#applyChangeset', () => {
@@ -189,12 +197,12 @@ describe('jsonDiff#valueKey', () => {
     expect(diffs).toMatchSnapshot();
   });
 
-  it('corretly flatten array value keys', () => {
+  it('correctly flatten array value keys', () => {
     const flattenChanges = atomizeChangeset(diff(oldObj, newObj, { embeddedObjKeys: { items: '$value' } }));
     expect(flattenChanges).toMatchSnapshot();
   });
 
-  it('corretly unflatten array value keys', () => {
+  it('correctly unflatten array value keys', () => {
     const flattenChanges = [
       {
         key: 'lemon',


### PR DESCRIPTION
Noticed errors occurring when diffs were created for an object where a value was changing from an array to undefined with `treatTypeChangeAsReplace` set to false. This MR adds some more guards against different combinations of values. Changes to array handling prevents runtime errors, changes to undefined handling is purely QoL.