### PR TITLE
fix: remove empty REMOVE operations and fix array handling

### DIFF
--- a/CHANGELOG/array-handling-fix.md
+++ b/CHANGELOG/array-handling-fix.md
@@ -1,0 +1,22 @@
+# Fix for array handling in applyChangeset and revertChangeset
+
+## Bug
+In the functions `applyArrayChange` and `revertArrayChange`, the return value was not being used correctly. Both functions were returning an array of operation results rather than the modified array itself.
+
+The issue didn't affect functionality because the arrays were being modified in-place by the operations, but it made the code less clear and consistent with other functions.
+
+## Fix
+Modified both `applyArrayChange` and `revertArrayChange` functions to:
+
+1. Remove the IIFE (Immediately Invoked Function Expression) pattern
+2. Directly modify the array in-place
+3. Return the modified array for consistency with other functions
+4. Add proper JSDoc comments to clarify the behavior
+
+Also added support for the `$value` embeddedKey in the `revertArrayChange` function for consistency.
+
+## Tests
+Added comprehensive tests to verify that the changes work as expected, including:
+1. Simple array modifications using ID as the key
+2. Array modifications using the default index as the key
+3. Complex nested array changes with multiple levels of nesting

--- a/CHANGELOG/empty-remove-fix.md
+++ b/CHANGELOG/empty-remove-fix.md
@@ -1,0 +1,31 @@
+# Fix for empty REMOVE operations when diffing from undefined
+
+## Bug
+When diffing from `undefined` to a value, the `diff` function was generating an empty REMOVE operation for the root key:
+
+```typescript
+const value = { DBA: "New Val" };
+const valueDiff = diff(undefined, value);
+// Results in:
+// [
+//   {"key": "$root", "type": "REMOVE"},                        // Empty REMOVE operation
+//   {"key": "$root", "type": "ADD", "value": {"DBA": "New Val"}}
+// ]
+```
+
+This empty REMOVE operation is unnecessary since there's nothing to remove when starting from `undefined`.
+
+## Fix
+Updated the condition in the `compare` function to only add a REMOVE operation if the old object is not `undefined`:
+
+```typescript
+// Only add a REMOVE operation if oldObj is not undefined
+if (typeOfOldObj !== 'undefined') {
+  changes.push({ type: Operation.REMOVE, key: getKey(path), value: oldObj });
+}
+```
+
+## Tests
+Added tests to verify:
+1. When diffing from `undefined` to a value, no REMOVE operation is generated
+2. When diffing from a value to `undefined`, a REMOVE operation with the original value is generated

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -585,29 +585,39 @@ const applyLeafChange = (obj: any, change: any, embeddedKey: any) => {
   }
 };
 
-const applyArrayChange = (arr: any, change: any) =>
-  (() => {
-    const result = [];
-    for (const subchange of change.changes) {
-      if (subchange.value != null || subchange.type === Operation.REMOVE) {
-        result.push(applyLeafChange(arr, subchange, change.embeddedKey));
-      } else {
-        let element;
-        if (change.embeddedKey === '$index') {
-          element = arr[subchange.key];
-        } else if (change.embeddedKey === '$value') {
-          const index = arr.indexOf(subchange.key);
-          if (index !== -1) {
-            element = arr[index];
-          }
-        } else {
-          element = find(arr, (el) => el[change.embeddedKey]?.toString() === subchange.key.toString());
+/**
+ * Applies changes to an array.
+ * 
+ * @param {any[]} arr - The array to apply changes to.
+ * @param {any} change - The change to apply, containing nested changes.
+ * @returns {any[]} - The array after changes have been applied.
+ *
+ * Note: This function modifies the array in-place but also returns it for
+ * consistency with other functions.
+ */
+const applyArrayChange = (arr: any, change: any) => {
+  for (const subchange of change.changes) {
+    if (subchange.value != null || subchange.type === Operation.REMOVE) {
+      applyLeafChange(arr, subchange, change.embeddedKey);
+    } else {
+      let element;
+      if (change.embeddedKey === '$index') {
+        element = arr[subchange.key];
+      } else if (change.embeddedKey === '$value') {
+        const index = arr.indexOf(subchange.key);
+        if (index !== -1) {
+          element = arr[index];
         }
-        result.push(applyChangeset(element, subchange.changes));
+      } else {
+        element = find(arr, (el) => el[change.embeddedKey]?.toString() === subchange.key.toString());
+      }
+      if (element) {
+        applyChangeset(element, subchange.changes);
       }
     }
-    return result;
-  })();
+  }
+  return arr;
+};
 
 const applyBranchChange = (obj: any, change: any) => {
   if (Array.isArray(obj)) {
@@ -629,24 +639,39 @@ const revertLeafChange = (obj: any, change: any, embeddedKey = '$index') => {
   }
 };
 
-const revertArrayChange = (arr: any, change: any) =>
-  (() => {
-    const result = [];
-    for (const subchange of change.changes) {
-      if (subchange.value != null || subchange.type === Operation.REMOVE) {
-        result.push(revertLeafChange(arr, subchange, change.embeddedKey));
-      } else {
-        let element;
-        if (change.embeddedKey === '$index') {
-          element = arr[+subchange.key];
-        } else {
-          element = find(arr, (el) => el[change.embeddedKey].toString() === subchange.key);
+/**
+ * Reverts changes in an array.
+ * 
+ * @param {any[]} arr - The array to revert changes in.
+ * @param {any} change - The change to revert, containing nested changes.
+ * @returns {any[]} - The array after changes have been reverted.
+ *
+ * Note: This function modifies the array in-place but also returns it for
+ * consistency with other functions.
+ */
+const revertArrayChange = (arr: any, change: any) => {
+  for (const subchange of change.changes) {
+    if (subchange.value != null || subchange.type === Operation.REMOVE) {
+      revertLeafChange(arr, subchange, change.embeddedKey);
+    } else {
+      let element;
+      if (change.embeddedKey === '$index') {
+        element = arr[+subchange.key];
+      } else if (change.embeddedKey === '$value') {
+        const index = arr.indexOf(subchange.key);
+        if (index !== -1) {
+          element = arr[index];
         }
-        result.push(revertChangeset(element, subchange.changes));
+      } else {
+        element = find(arr, (el) => el[change.embeddedKey]?.toString() === subchange.key.toString());
+      }
+      if (element) {
+        revertChangeset(element, subchange.changes);
       }
     }
-    return result;
-  })();
+  }
+  return arr;
+};
 
 const revertBranchChange = (obj: any, change: any) => {
   if (Array.isArray(obj)) {

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -344,7 +344,10 @@ const compare = (oldObj: any, newObj: any, path: any, keyPath: any, options: Opt
 
   // `treatTypeChangeAsReplace` is a flag used to determine if a change in type should be treated as a replacement.
   if (options.treatTypeChangeAsReplace && typeOfOldObj !== typeOfNewObj) {
-    changes.push({ type: Operation.REMOVE, key: getKey(path), value: oldObj });
+    // Only add a REMOVE operation if oldObj is not undefined
+    if (typeOfOldObj !== 'undefined') {
+      changes.push({ type: Operation.REMOVE, key: getKey(path), value: oldObj });
+    }
 
     // As undefined is not serialized into JSON, it should not count as an added value.
     if (typeOfNewObj !== 'undefined') {

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -205,6 +205,131 @@ describe('jsonDiff#flatten', () => {
   });
 });
 
+describe('jsonDiff#arrayHandling', () => {
+  it('should correctly apply changes to nested arrays with id key', () => {
+    // Initial object with a nested array
+    const obj1 = {
+      items: [
+        { id: 1, name: 'item1' },
+        { id: 2, name: 'item2' },
+        { id: 3, name: 'item3' }
+      ]
+    };
+    
+    // Modified object with changes in the nested array
+    const obj2 = {
+      items: [
+        { id: 1, name: 'item1-modified' }, // Modified name
+        { id: 3, name: 'item3' },          // Item 2 removed, item 3 is now at index 1
+        { id: 4, name: 'item4' }           // New item added
+      ]
+    };
+    
+    const changes = diff(obj1, obj2, {
+      embeddedObjKeys: {
+        items: 'id'  // Use 'id' as the key for the items array
+      }
+    });
+    
+    // Make a copy of obj1 to apply changes to
+    const objCopy = JSON.parse(JSON.stringify(obj1));
+    
+    // Apply the changes to the copy
+    const result = applyChangeset(objCopy, changes);
+    
+    // The result should match obj2
+    expect(result).toEqual(obj2);
+  });
+
+  it('should correctly apply changes to nested arrays with index key', () => {
+    // Initial object with a nested array
+    const obj1 = {
+      items: [
+        { id: 1, name: 'item1' },
+        { id: 2, name: 'item2' },
+        { id: 3, name: 'item3' }
+      ]
+    };
+    
+    // Modified object with changes in the nested array
+    const obj2 = {
+      items: [
+        { id: 1, name: 'item1-modified' }, // Modified name
+        { id: 3, name: 'item3-modified' }, // Modified name
+        { id: 4, name: 'item4' }           // New item (replacing item2)
+      ]
+    };
+    
+    // Using no embeddedObjKeys to use the default $index
+    const changes = diff(obj1, obj2);
+    
+    // Make a copy of obj1 to apply changes to
+    const objCopy = JSON.parse(JSON.stringify(obj1));
+    
+    // Apply the changes to the copy
+    const result = applyChangeset(objCopy, changes);
+    
+    // The result should match obj2
+    expect(result).toEqual(obj2);
+  });
+
+  it('should correctly apply complex nested array changes', () => {
+    // Initial object with nested arrays
+    const obj1 = {
+      departments: [
+        {
+          name: 'Engineering',
+          teams: [
+            { id: 'team1', name: 'Frontend', members: ['Alice', 'Bob'] },
+            { id: 'team2', name: 'Backend', members: ['Charlie', 'Dave'] }
+          ]
+        },
+        {
+          name: 'Marketing',
+          teams: [
+            { id: 'team3', name: 'Digital', members: ['Eve', 'Frank'] }
+          ]
+        }
+      ]
+    };
+    
+    // Modified object with nested array changes
+    const obj2 = {
+      departments: [
+        {
+          name: 'Engineering',
+          teams: [
+            { id: 'team1', name: 'Frontend Dev', members: ['Alice', 'Bob', 'Grace'] }, // Changed name, added member
+            { id: 'team4', name: 'DevOps', members: ['Heidi'] } // New team
+          ]
+        },
+        {
+          name: 'Marketing',
+          teams: [
+            { id: 'team3', name: 'Digital Marketing', members: ['Eve', 'Ivy'] } // Changed name, replaced member
+          ]
+        }
+      ]
+    };
+    
+    const changes = diff(obj1, obj2, {
+      embeddedObjKeys: {
+        'departments': 'name',
+        'departments.teams': 'id'
+      }
+    });
+    
+    // Make a copy of obj1 to apply changes to
+    const objCopy = JSON.parse(JSON.stringify(obj1));
+    
+    // Apply the changes to the copy
+    const result = applyChangeset(objCopy, changes);
+    
+    // The result should match obj2
+    expect(result).toEqual(obj2);
+  });
+});
+
 describe('jsonDiff#valueKey', () => {
   let oldObj: any;
   let newObj: any;

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -69,6 +69,33 @@ describe('jsonDiff#diff', () => {
       expect(diff(oldVal, newVal, { treatTypeChangeAsReplace: false })).toEqual(expectedUpdate);
     }
   );
+
+  it('should not include empty REMOVE operation when diffing from undefined to a value', () => {
+    const value = { DBA: "New Val" };
+    const valueDiff = diff(undefined, value);
+    
+    // Check that there's no REMOVE operation
+    const removeOperation = valueDiff.find(change => change.type === 'REMOVE');
+    
+    expect(removeOperation).toBeUndefined();
+    
+    // Check that there's only an ADD operation
+    expect(valueDiff.length).toBe(1);
+    expect(valueDiff[0].type).toBe('ADD');
+    expect(valueDiff[0].key).toBe('$root');
+    expect(valueDiff[0].value).toEqual(value);
+  });
+  
+  it('should include a REMOVE operation with value when diffing from a value to undefined', () => {
+    const value = { DBA: "New Val" };
+    const valueDiff = diff(value, undefined);
+    
+    // Check if there's a REMOVE operation with the original value
+    expect(valueDiff.length).toBe(1);
+    expect(valueDiff[0].type).toBe('REMOVE');
+    expect(valueDiff[0].key).toBe('$root');
+    expect(valueDiff[0].value).toEqual(value);
+  });
 });
 
 describe('jsonDiff#applyChangeset', () => {


### PR DESCRIPTION
## Summary
This PR includes two fixes:

1. Fixed issue where diffing from undefined to a value generated an unnecessary empty REMOVE operation (addresses #204)
2. Fixed array handling in applyChangeset and revertChangeset functions (addresses #206)

## Fix for issue #204
- Modified the condition in the compare function to only add a REMOVE operation if the old object is not undefined
- Added tests to verify the behavior

## Fix for issue #206
- Modified both applyArrayChange and revertArrayChange functions to:
  - Remove the IIFE pattern
  - Directly modify the array in-place
  - Return the modified array for consistency
  - Add proper JSDoc comments
- Added support for the  embeddedKey in revertArrayChange
- Added comprehensive tests for array handling

Fixes #204
Fixes #206