### PR TITLE
Fix PR #201 to support both ES modules and CommonJS

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,9 +1,10 @@
 // jest.config.js
 export default {
-  preset: 'ts-jest/presets/default', // or other ESM presets (use ts-jest/presets/default-esm if lodash-es is used)
+  preset: 'ts-jest/presets/default-esm', // Using ESM preset for lodash-es
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
-    'lodash-es': 'lodash'
+    '^lodash-es$': 'lodash',
+    '^lodash-es/(.*)$': 'lodash/$1'
   },
   transform: {
     // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
@@ -11,7 +12,7 @@ export default {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        useESM: false // true if lodash-es is used
+        useESM: true // Enabled for lodash-es
       }
     ]
   }

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -2,7 +2,8 @@
 export default {
   preset: 'ts-jest/presets/default', // or other ESM presets (use ts-jest/presets/default-esm if lodash-es is used)
   moduleNameMapper: {
-    '^(\\.{1,2}/.*)\\.js$': '$1'
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    'lodash-es': 'lodash'
   },
   transform: {
     // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.7",
+        "@types/lodash": "^4.17.13",
         "@types/lodash-es": "^4.17.12",
         "eslint": "^9.1.1",
         "jest": "^29.7.0",
+        "lodash": "^4.17.21",
         "prettier": "^3.0.3",
         "ts-jest": "^29.0.5",
         "tsup": "^8.0.2",
@@ -4521,6 +4523,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -9293,6 +9302,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash-es": {
       "version": "4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "json-diff-ts",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "json-diff-ts",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
-        "lodash": "4.x"
+        "lodash-es": "^4.17.21"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.7",
-        "@types/lodash": "^4.17.0",
+        "@types/lodash-es": "^4.17.12",
         "eslint": "^9.1.1",
         "jest": "^29.7.0",
         "prettier": "^3.0.3",
@@ -2063,10 +2063,21 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
-      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
-      "dev": true
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.8.10",
@@ -4511,10 +4522,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
+    "node_modules/lodash-es": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7468,10 +7480,19 @@
       }
     },
     "@types/lodash": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
-      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
       "dev": true
+    },
+    "@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/node": {
       "version": "20.8.10",
@@ -9273,10 +9294,10 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
+    "lodash-es": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.7",
-    "@types/lodash": "^4.17.0",
+    "@types/lodash-es": "^4.17.12",
     "eslint": "^9.1.1",
     "jest": "^29.7.0",
     "prettier": "^3.0.3",
@@ -50,6 +50,6 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "lodash": "4.x"
+    "lodash-es": "^4.17.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsup --format cjs,esm",
     "format": "prettier --write \"src/**/*.ts\"",
@@ -41,9 +48,11 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.7",
+    "@types/lodash": "^4.17.13",
     "@types/lodash-es": "^4.17.12",
     "eslint": "^9.1.1",
     "jest": "^29.7.0",
+    "lodash": "^4.17.21",
     "prettier": "^3.0.3",
     "ts-jest": "^29.0.5",
     "tsup": "^8.0.2",

--- a/src/jsonCompare.ts
+++ b/src/jsonCompare.ts
@@ -1,4 +1,4 @@
-import { chain, keys, replace, set } from 'lodash';
+import { chain, keys, replace, set } from 'lodash-es';
 import { diff, atomizeChangeset, getTypeOfObj, IAtomicChange, Operation } from './jsonDiff.js';
 
 enum CompareOperation {

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -1,4 +1,4 @@
-import { difference, find, intersection, keyBy } from 'lodash';
+import { difference, find, intersection, keyBy } from 'lodash-es';
 import { splitJSONPath } from './helpers';
 
 type FunctionKey = (obj: any, shouldReturnKeyName?: boolean) => any;

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import {isEqual} from 'lodash-es';
 import {
   applyChangeset,
   diff,
@@ -80,7 +80,7 @@ describe('jsonDiff#applyChangeset', () => {
 
   it('applies changesetWithoutKey to oldObj correctly', () => {
     applyChangeset(oldObj, fixtures.changesetWithoutEmbeddedKey);
-    expect(_.isEqual(oldObj, newObj)).toBe(true);
+    expect(isEqual(oldObj, newObj)).toBe(true);
   });
 
   it('ignores removal of non-existing array elements', () => {
@@ -93,13 +93,13 @@ describe('jsonDiff#applyChangeset', () => {
 describe('jsonDiff#revertChangeset', () => {
   it('reverts changeset on newObj correctly', () => {
     revertChangeset(newObj, fixtures.changeset);
-    expect(_.isEqual(oldObj, newObj)).toBe(true);
+    expect(isEqual(oldObj, newObj)).toBe(true);
   });
 
   it('reverts changesetWithoutKey on newObj correctly', () => {
     revertChangeset(newObj, fixtures.changesetWithoutEmbeddedKey);
     newObj.children.sort((a: any, b: any) => a.name > b.name);
-    expect(_.isEqual(oldObj, newObj)).toBe(true);
+    expect(isEqual(oldObj, newObj)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Improves PR #201 to maintain dual module system compatibility
- Uses lodash-es for ES module builds while ensuring CommonJS compatibility
- Updates Jest configuration to properly test with ES modules
- Adds exports field to package.json for explicit module resolution

## Test plan
- Verified both formats build correctly with `npm run build`
- All tests pass when running `npm test`
- Type definitions are properly generated for both module systems

🤖 Generated with [Claude Code](https://claude.ai/code)