### PR TITLE
Fix issue #221: Remove undefined assignment in removeKey

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-diff-ts",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A JSON diff tool for JavaScript written in TypeScript.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -557,7 +557,6 @@ const removeKey = (obj: any, key: any, embeddedKey: any) => {
     }
     return obj.splice(index != null ? index : key, 1);
   } else {
-    obj[key] = undefined;
     delete obj[key];
     return;
   }

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -378,6 +378,32 @@ describe('jsonDiff#arrayHandling', () => {
   });
 });
 
+describe('jsonDiff#removeKey', () => {
+  it('should correctly delete properties without undefined assignment (issue #221)', () => {
+    // Test object with a property to be removed
+    const obj = {
+      foo: 'bar',
+      baz: 'qux'
+    };
+    
+    // Create a diff that will remove the 'foo' property
+    const changes = diff(obj, { baz: 'qux' });
+    
+    // Verify the change operation is a REMOVE
+    expect(changes.length).toBe(1);
+    expect(changes[0].type).toBe('REMOVE');
+    expect(changes[0].key).toBe('foo');
+    
+    // Apply the changeset to remove the property
+    applyChangeset(obj, changes);
+    
+    // Check that the property was completely removed without any undefined residue
+    expect(obj).toEqual({ baz: 'qux' });
+    expect(obj.hasOwnProperty('foo')).toBe(false);
+    expect(Object.keys(obj)).toEqual(['baz']);
+  });
+});
+
 describe('jsonDiff#valueKey', () => {
   let oldObj: any;
   let newObj: any;


### PR DESCRIPTION
## Summary
- Removes unnecessary assignment to undefined before deleting a key in the removeKey function
- Adds a unit test to verify the fix works correctly
- Bumps version to 4.2.1 for this bugfix release

## Description
When using json-diff-ts with Automerge, the unnecessary assignment to undefined before property deletion was causing issues. This PR removes that line while maintaining full test coverage.

Fixes #221

🤖 Generated with [Claude Code](https://claude.ai/code)