### PR TITLE
Bump to v4.4.0 with release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ const diffs = diff(oldData, newData, { embeddedObjKeys: { '.characters.subarray'
 const diffs = diff(oldData, newData, { treatTypeChangeAsReplace: false });
 ```
 
+Date objects can now be updated to primitive values without errors when `treatTypeChangeAsReplace` is set to `false`.
+
 ##### Skip Nested Paths
 
 ```javascript
@@ -186,6 +188,7 @@ const value = jsonPath.query(data, '$.characters[?(@.id=="LUK")].name');
 
 ## Release Notes
 
+- **v4.4.0:** Fixed Date-to-string diff when `treatTypeChangeAsReplace` is false
 - **v4.3.0:** Enhanced functionality:
   - Added support for nested keys to skip using dotted path notation in the keysToSkip option
   - This allows excluding specific nested object paths from comparison (fixes #242)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-diff-ts",
-  "version": "4.2.2",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "json-diff-ts",
-      "version": "4.2.2",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "4.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-diff-ts",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "A JSON diff tool for JavaScript written in TypeScript.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -418,13 +418,17 @@ const compare = (oldObj: any, newObj: any, path: any, keyPath: any, options: Opt
 
   switch (typeOfOldObj) {
     case 'Date':
-      changes = changes.concat(
-        comparePrimitives(oldObj.getTime(), newObj.getTime(), path).map((x) => ({
-          ...x,
-          value: new Date(x.value),
-          oldValue: new Date(x.oldValue)
-        }))
-      );
+      if (typeOfNewObj === 'Date') {
+        changes = changes.concat(
+          comparePrimitives(oldObj.getTime(), newObj.getTime(), path).map((x) => ({
+            ...x,
+            value: new Date(x.value),
+            oldValue: new Date(x.oldValue)
+          }))
+        );
+      } else {
+        changes = changes.concat(comparePrimitives(oldObj, newObj, path));
+      }
       break;
     case 'Object': {
       const diffs = compareObject(oldObj, newObj, path, keyPath, false, options);

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -137,6 +137,18 @@ describe('jsonDiff#diff', () => {
     expect(valueDiff[0].key).toBe('$root');
     expect(valueDiff[0].value).toEqual(value);
   });
+
+  it('handles Date to string updates when treatTypeChangeAsReplace is false (issue #254)', () => {
+    const d = '2025-05-28T06:40:53.284Z';
+    const before = { d: new Date(d) };
+    const after = { d };
+
+    const valueDiff = diff(before, after, { treatTypeChangeAsReplace: false });
+
+    expect(valueDiff).toEqual([
+      { type: 'UPDATE', key: 'd', value: d, oldValue: new Date(d) }
+    ]);
+  });
 });
 
 describe('jsonDiff#applyChangeset', () => {


### PR DESCRIPTION
## Summary
- bump version number to 4.4.0
- document Date-to-string diff support in README
- add release note for v4.4.0

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f104f5e3c83248f152f74405faf60