### PR TITLE
Replace lodash with es-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ const value = jsonPath.query(data, '$.characters[?(@.id=="LUK")].name');
 
 ## Release Notes
 
+- **v4.5.0:** Switched internal utilities from lodash to es-toolkit/compat for a smaller bundle size
 - **v4.4.0:** Fixed Date-to-string diff when `treatTypeChangeAsReplace` is false
 - **v4.3.0:** Enhanced functionality:
   - Added support for nested keys to skip using dotted path notation in the keysToSkip option

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,20 @@
 {
   "name": "json-diff-ts",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "json-diff-ts",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
-        "lodash": "4.x"
+        "es-toolkit": "^1.39.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.8.0",
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.7",
-        "@types/lodash": "^4.17.0",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
         "prettier": "^3.0.3",
@@ -2157,13 +2156,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.16",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
-      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "20.8.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
@@ -3120,6 +3112,16 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.3",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.3.tgz",
+      "integrity": "sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.1",
@@ -4804,11 +4806,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7904,12 +7901,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "@types/lodash": {
-      "version": "4.17.16",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
-      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
-      "dev": true
-    },
     "@types/node": {
       "version": "20.8.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
@@ -8555,6 +8546,11 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "es-toolkit": {
+      "version": "1.39.3",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.3.tgz",
+      "integrity": "sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww=="
     },
     "esbuild": {
       "version": "0.25.1",
@@ -9799,11 +9795,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-diff-ts",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "A JSON diff tool for JavaScript written in TypeScript.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -42,16 +42,15 @@
     "@eslint/js": "^9.8.0",
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.7",
-    "@types/lodash": "^4.17.0",
     "eslint": "^8.56.0",
-    "typescript-eslint": "^8.31.0",
     "jest": "^29.7.0",
     "prettier": "^3.0.3",
     "ts-jest": "^29.0.5",
     "tsup": "^8.0.2",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "typescript-eslint": "^8.31.0"
   },
   "dependencies": {
-    "lodash": "4.x"
+    "es-toolkit": "^1.39.3"
   }
 }

--- a/src/jsonCompare.ts
+++ b/src/jsonCompare.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { set } from 'es-toolkit/compat';
 import { diff, atomizeChangeset, getTypeOfObj, IAtomicChange, Operation } from './jsonDiff.js';
 
 enum CompareOperation {
@@ -60,10 +60,10 @@ const applyChangelist = (object: IComparisonEnrichedNode, changelist: IAtomicCha
       switch (entry.type) {
         case Operation.ADD:
         case Operation.UPDATE:
-          _.set(object, entry.path, { type: entry.type, value: entry.value, oldValue: entry.oldValue });
+          set(object, entry.path, { type: entry.type, value: entry.value, oldValue: entry.oldValue });
           break;
         case Operation.REMOVE:
-          _.set(object, entry.path, { type: entry.type, value: undefined, oldValue: entry.value });
+          set(object, entry.path, { type: entry.type, value: undefined, oldValue: entry.value });
           break;
         default:
           throw new Error();

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { difference, intersection, keyBy } from 'es-toolkit/compat';
 import { splitJSONPath } from './helpers.js';
 
 type FunctionKey = (obj: any, shouldReturnKeyName?: boolean) => any;
@@ -473,7 +473,7 @@ const compareObject = (oldObj: any, newObj: any, path: any, keyPath: any, skipPa
   const oldObjKeys = Object.keys(oldObj);
   const newObjKeys = Object.keys(newObj);
 
-  const intersectionKeys = _.intersection(oldObjKeys, newObjKeys);
+  const intersectionKeys = intersection(oldObjKeys, newObjKeys);
   for (k of intersectionKeys) {
     newPath = path.concat([k]);
     newKeyPath = skipPath ? keyPath : keyPath.concat([k]);
@@ -483,7 +483,7 @@ const compareObject = (oldObj: any, newObj: any, path: any, keyPath: any, skipPa
     }
   }
 
-  const addedKeys = _.difference(newObjKeys, oldObjKeys);
+  const addedKeys = difference(newObjKeys, oldObjKeys);
   for (k of addedKeys) {
     newPath = path.concat([k]);
     newKeyPath = skipPath ? keyPath : keyPath.concat([k]);
@@ -499,7 +499,7 @@ const compareObject = (oldObj: any, newObj: any, path: any, keyPath: any, skipPa
     });
   }
 
-  const deletedKeys = _.difference(oldObjKeys, newObjKeys);
+  const deletedKeys = difference(oldObjKeys, newObjKeys);
   for (k of deletedKeys) {
     newPath = path.concat([k]);
     newKeyPath = skipPath ? keyPath : keyPath.concat([k]);
@@ -572,7 +572,7 @@ const convertArrayToObj = (arr: any[], uniqKey: any) => {
       obj[value] = value;
     });
   } else if (uniqKey !== '$index') {
-    obj = _.keyBy(arr, uniqKey);
+    obj = keyBy(arr, uniqKey);
   } else {
     for (let i = 0; i < arr.length; i++) {
       const value = arr[i];

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { isEqual } from 'es-toolkit/compat';
 import {
   applyChangeset,
   diff,
@@ -160,7 +160,7 @@ describe('jsonDiff#applyChangeset', () => {
 
   it('applies changesetWithoutKey to oldObj correctly', () => {
     applyChangeset(oldObj, fixtures.changesetWithoutEmbeddedKey);
-    expect(_.isEqual(oldObj, newObj)).toBe(true);
+    expect(isEqual(oldObj, newObj)).toBe(true);
   });
 
   it('ignores removal of non-existing array elements', () => {
@@ -193,13 +193,13 @@ describe('jsonDiff#applyChangeset', () => {
 describe('jsonDiff#revertChangeset', () => {
   it('reverts changeset on newObj correctly', () => {
     revertChangeset(newObj, fixtures.changeset);
-    expect(_.isEqual(oldObj, newObj)).toBe(true);
+    expect(isEqual(oldObj, newObj)).toBe(true);
   });
 
   it('reverts changesetWithoutKey on newObj correctly', () => {
     revertChangeset(newObj, fixtures.changesetWithoutEmbeddedKey);
     newObj.children.sort((a: any, b: any) => a.name > b.name);
-    expect(_.isEqual(oldObj, newObj)).toBe(true);
+    expect(isEqual(oldObj, newObj)).toBe(true);
   });
 
   it('correctly reverts null values', () => {


### PR DESCRIPTION
## Summary
- swap lodash for `es-toolkit/compat`
- update tests to use `es-toolkit` utilities
- document the change in the release notes
- bump version to 4.5.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f16a4846c83248f5abebf7d602a9e