### PR TITLE
Release v4.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ const value = jsonPath.query(data, '$.characters[?(@.id=="LUK")].name');
 
 ## Release Notes
 
+- **v4.6.0:** Fixed filter path regex to avoid polynomial complexity
 - **v4.5.1:** Updated package dependencies
 - **v4.5.0:** Switched internal utilities from lodash to es-toolkit/compat for a smaller bundle size
 - **v4.4.0:** Fixed Date-to-string diff when `treatTypeChangeAsReplace` is false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-diff-ts",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "json-diff-ts",
-      "version": "4.5.1",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "es-toolkit": "^1.39.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-diff-ts",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "A JSON diff tool for JavaScript written in TypeScript.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump version to **v4.6.0**
- document `v4.6.0` release note

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851da5f66308324a0e3a2768f7c1dc7