### PR TITLE
Fix array path format

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ const value = jsonPath.query(data, '$.characters[?(@.id=="LUK")].name');
 
 ## Release Notes
 
+- **v4.6.1:** Consistent JSONPath format for array items (fixes issue #269)
 - **v4.6.0:** Fixed filter path regex to avoid polynomial complexity
 - **v4.5.1:** Updated package dependencies
 - **v4.5.0:** Switched internal utilities from lodash to es-toolkit/compat for a smaller bundle size

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-diff-ts",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "A JSON diff tool for JavaScript written in TypeScript.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -221,9 +221,6 @@ function handleEmbeddedKey(embeddedKey: string | FunctionKey, obj: IChange, path
         }
       ]
     ];
-  } else if (obj.type === Operation.ADD) {
-    // do nothing
-    return [path];
   } else {
     path = filterExpression(path, embeddedKey, obj.key);
     return [path];

--- a/tests/__snapshots__/jsonDiff.test.ts.snap
+++ b/tests/__snapshots__/jsonDiff.test.ts.snap
@@ -823,7 +823,7 @@ exports[`jsonDiff#flatten gets key name for flattening when using a key function
 [
   {
     "key": "2",
-    "path": "$.items.2",
+    "path": "$.items[?(@._id=='2')]",
     "type": "ADD",
     "value": {
       "_id": "2",

--- a/tests/atomizeChangeset.test.ts
+++ b/tests/atomizeChangeset.test.ts
@@ -19,8 +19,8 @@ describe('atomizeChangeset', () => {
     const actual = atomizeChangeset(diffs);
 
     expect(actual.length).toBe(2);
-    // In the new implementation, keys are always appended to paths
-    expect(actual[0].path).toBe('$[a.b].2');
+    // With embedded keys, paths use filter expressions
+    expect(actual[0].path).toBe("$[a.b][?(@.c=='2')]");
     expect(actual[1].path).toBe("$[a.b][?(@.c=='1')]");
     done();
   });
@@ -33,8 +33,8 @@ describe('atomizeChangeset', () => {
     const actual = atomizeChangeset(diffs);
 
     expect(actual.length).toBe(2);
-    // In the new implementation, keys are always appended to paths
-    expect(actual[0].path).toBe('$.a.20');
+    // With embedded keys containing periods, use filter expressions
+    expect(actual[0].path).toBe("$.a[?(@[c.d]=='20')]");
     expect(actual[1].path).toBe("$.a[?(@[c.d]=='10')]");
     done();
   });


### PR DESCRIPTION
## Summary
- return filter expression paths for ADD operations
- update atomizeChangeset tests for new paths
- update snapshot to match new JSONPath formatting
- document release notes for v4.6.1

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851dee403488324adb81ae5a6110503