### PR TITLE
Fix updating object to `null` in `treatTypeChangeAsReplace: false` scenario

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-diff-ts",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "json-diff-ts",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
         "es-toolkit": "^1.39.3"

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -428,6 +428,11 @@ const compare = (oldObj: any, newObj: any, path: any, keyPath: any, options: Opt
     return changes;
   }
 
+  if (typeOfNewObj === null) {
+    changes.push({ type: Operation.UPDATE, key: getKey(path), value: newObj, oldValue: oldObj });
+    return changes;
+  }
+
   switch (typeOfOldObj) {
     case 'Date':
       if (typeOfNewObj === 'Date') {

--- a/tests/__fixtures__/jsonDiff.fixture.ts
+++ b/tests/__fixtures__/jsonDiff.fixture.ts
@@ -334,6 +334,41 @@ export const assortedDiffs: {
     expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: null, oldValue: [] }]
   },
   {
+    oldVal: {},
+    newVal: null,
+    expectedReplacement: [
+      { type: Operation.REMOVE, key: '$root', value: {} },
+      { type: Operation.ADD, key: '$root', value: null }
+    ],
+    expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: null, oldValue: {} }]
+  },
+  {
+    oldVal: undefined,
+    newVal: null,
+    expectedReplacement: [
+      { type: Operation.ADD, key: '$root', value: null }
+    ],
+    expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: null, oldValue: undefined }]
+  },
+  {
+    oldVal: 1,
+    newVal: null,
+    expectedReplacement: [
+      { type: Operation.REMOVE, key: '$root', value: 1 },
+      { type: Operation.ADD, key: '$root', value: null }
+    ],
+    expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: null, oldValue: 1 }]
+  },
+  {
+    oldVal: [],
+    newVal: null,
+    expectedReplacement: [
+      { type: Operation.REMOVE, key: '$root', value: [] },
+      { type: Operation.ADD, key: '$root', value: null }
+    ],
+    expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: null, oldValue: [] }]
+  },
+  {
     oldVal: [],
     newVal: undefined,
     expectedReplacement: [{ type: Operation.REMOVE, key: '$root', value: [] }],


### PR DESCRIPTION
Hey! Great library!

We have run into an issue with not correctly handling changes to `null` value. This PR fixes that.

Current version:
```ts
const { diff } = require("json-diff-ts")

oldValues = { value: null }
newValues = { value: { some: "value" } }

diff(oldValues, newValues, { treatTypeChangeAsReplace: false })
// [
//   {
//     type: 'UPDATE',
//     key: 'value',
//     value: { some: 'value' },
//     oldValue: null
//   }
// ]

diff(newValues, oldValues, { treatTypeChangeAsReplace: false })
// Uncaught TypeError: Cannot convert undefined or null to object
//     at Function.keys (<anonymous>)
```

After merging this
```ts
diff(newValues, oldValues, { treatTypeChangeAsReplace: false })
// [
//   {
//     type: 'UPDATE',
//     key: 'value',
//     value: null,
//     oldValue: { some: 'value' }
//   }
// ]
```

Let me know if you need anything from my side.