### PR TITLE
Fix null comparison bug and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ const value = jsonPath.query(data, '$.characters[?(@.id=="LUK")].name');
 
 ## Release Notes
 
+- **v4.6.3:** Fixed null comparison returning update when values are both null (fixes issue #284)
+
 - **v4.6.2:** Fixed updating to null when `treatTypeChangeAsReplace` is false and bumped Jest dev dependencies
 - **v4.6.1:** Consistent JSONPath format for array items (fixes issue #269)
 - **v4.6.0:** Fixed filter path regex to avoid polynomial complexity

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-diff-ts",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "json-diff-ts",
-      "version": "4.6.2",
+      "version": "4.6.3",
       "license": "MIT",
       "dependencies": {
         "es-toolkit": "^1.39.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-diff-ts",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "A JSON diff tool for JavaScript written in TypeScript.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -429,7 +429,9 @@ const compare = (oldObj: any, newObj: any, path: any, keyPath: any, options: Opt
   }
 
   if (typeOfNewObj === null) {
-    changes.push({ type: Operation.UPDATE, key: getKey(path), value: newObj, oldValue: oldObj });
+    if (typeOfOldObj !== null) {
+      changes.push({ type: Operation.UPDATE, key: getKey(path), value: newObj, oldValue: oldObj });
+    }
     return changes;
   }
 

--- a/tests/__fixtures__/jsonDiff.fixture.ts
+++ b/tests/__fixtures__/jsonDiff.fixture.ts
@@ -392,4 +392,10 @@ export const assortedDiffs: {
     ],
     expectedUpdate: [{ type: Operation.UPDATE, key: '$root', value: 1, oldValue: [] }]
   },
+  {
+    oldVal: null,
+    newVal: null,
+    expectedReplacement: [],
+    expectedUpdate: []
+  },
 ];


### PR DESCRIPTION
## Summary
- fix comparing null values
- add regression test for comparing two nulls
- bump version to v4.6.3
- document the fix in release notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c4e9792488324869e63dba7b072e4