### PR TITLE
feat: detect and apply array move operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ interface Options {
 
 | Option | Type | Description |
 | ------ | ---- | ----------- |
-| `embeddedObjKeys` | `Record<string, string | Function>` or `Map<string | RegExp, string | Function>` | Map paths of arrays to a key or resolver function used to match elements when diffing. Use a `Map` for regex paths. |
+| `embeddedObjKeys` | `Record<string, string | Function>` or `Map<string | RegExp, string | Function>` | Map paths of arrays to a key or resolver function used to match elements when diffing. When provided, reorders are reported as `MOVE` operations. Use a `Map` for regex paths. |
 | `keysToSkip` | `string[]` | Dotted paths to exclude from comparison, e.g. `"meta.info"`. |
 | `treatTypeChangeAsReplace` | `boolean` | When `true` (default), a type change results in a REMOVE/ADD pair. Set to `false` to treat it as an UPDATE. |
 
@@ -304,10 +304,15 @@ interface Options {
 ```typescript
 enum Operation {
   REMOVE = 'REMOVE',
-  ADD = 'ADD', 
-  UPDATE = 'UPDATE'
+  ADD = 'ADD',
+  UPDATE = 'UPDATE',
+  // Reorder an existing array element identified by a unique key
+  MOVE = 'MOVE'
 }
 ```
+
+`MOVE` changes include `from` and `to` properties that describe the original and new indexes of the element. Move detection is
+enabled automatically when a corresponding path is specified in `embeddedObjKeys`.
 
 ## Release Notes
 

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -561,7 +561,7 @@ const compareArray = (oldObj: any, newObj: any, path: any, keyPath: any, options
   const indexedNewObj = convertArrayToObj(newObj, uniqKey);
   const diffs = compareObject(indexedOldObj, indexedNewObj, path, keyPath, true, options);
 
-  let moveDiffs: IChange[] = [];
+  const moveDiffs: IChange[] = [];
   if (left != null) {
     const getId = (item: any) =>
       uniqKey === '$value'

--- a/tests/__snapshots__/jsonDiff.test.ts.snap
+++ b/tests/__snapshots__/jsonDiff.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`jsonDiff#diff returns correct diff for object without keys to skip 1`] = `
 [
@@ -272,6 +272,18 @@ exports[`jsonDiff#diff returns correct diff for objects with embedded array with
   {
     "changes": [
       {
+        "from": 0,
+        "key": "kid1",
+        "to": 1,
+        "type": "MOVE",
+      },
+      {
+        "from": 1,
+        "key": "kid2",
+        "to": 2,
+        "type": "MOVE",
+      },
+      {
         "changes": [
           {
             "key": "age",
@@ -426,6 +438,18 @@ exports[`jsonDiff#diff returns correct diff for objects with embedded array with
   {
     "changes": [
       {
+        "from": 0,
+        "key": "kid1",
+        "to": 1,
+        "type": "MOVE",
+      },
+      {
+        "from": 1,
+        "key": "kid2",
+        "to": 2,
+        "type": "MOVE",
+      },
+      {
         "changes": [
           {
             "key": "age",
@@ -579,6 +603,18 @@ exports[`jsonDiff#diff returns correct diff for objects with embedded array with
   },
   {
     "changes": [
+      {
+        "from": 0,
+        "key": "kid1",
+        "to": 1,
+        "type": "MOVE",
+      },
+      {
+        "from": 1,
+        "key": "kid2",
+        "to": 2,
+        "type": "MOVE",
+      },
       {
         "changes": [
           {
@@ -855,6 +891,14 @@ exports[`jsonDiff#valueKey apply array value keys 1`] = `
 exports[`jsonDiff#valueKey correctly flatten array value keys 1`] = `
 [
   {
+    "from": 2,
+    "key": "orange",
+    "path": "$.items[?(@=='orange')]",
+    "to": 0,
+    "type": "MOVE",
+    "valueType": "undefined",
+  },
+  {
     "key": "lemon",
     "path": "$.items[?(@=='lemon')]",
     "type": "ADD",
@@ -883,8 +927,10 @@ exports[`jsonDiff#valueKey correctly unflatten array value keys 1`] = `
   {
     "changes": [
       {
+        "from": undefined,
         "key": "lemon",
         "oldValue": undefined,
+        "to": undefined,
         "type": "ADD",
         "value": "lemon",
       },
@@ -896,8 +942,10 @@ exports[`jsonDiff#valueKey correctly unflatten array value keys 1`] = `
   {
     "changes": [
       {
+        "from": undefined,
         "key": "apple",
         "oldValue": undefined,
+        "to": undefined,
         "type": "REMOVE",
         "value": "apple",
       },
@@ -933,6 +981,12 @@ exports[`jsonDiff#valueKey tracks array changes by array value 1`] = `
 [
   {
     "changes": [
+      {
+        "from": 2,
+        "key": "orange",
+        "to": 0,
+        "type": "MOVE",
+      },
       {
         "key": "lemon",
         "type": "ADD",

--- a/tests/jsonDiff.test.ts
+++ b/tests/jsonDiff.test.ts
@@ -149,6 +149,43 @@ describe('jsonDiff#diff', () => {
       { type: 'UPDATE', key: 'd', value: d, oldValue: new Date(d) }
     ]);
   });
+
+  it('detects MOVE operations for array sort', () => {
+    const before = { items: [{ id: 2 }, { id: 1 }, { id: 3 }] };
+    const after = { items: [{ id: 1 }, { id: 2 }, { id: 3 }] };
+    const changeset = diff(before, after, { embeddedObjKeys: { items: 'id' } });
+    expect(changeset[0].changes).toEqual(
+      expect.arrayContaining([
+        { type: Operation.MOVE, key: '1', from: 1, to: 0 },
+        { type: Operation.MOVE, key: '2', from: 0, to: 1 }
+      ])
+    );
+
+    applyChangeset(before, changeset);
+    expect(before).toEqual(after);
+
+    revertChangeset(before, changeset);
+    expect(before).toEqual({ items: [{ id: 2 }, { id: 1 }, { id: 3 }] });
+  });
+
+  it('detects MOVE operations for array shift', () => {
+    const before = { items: [{ id: 1 }, { id: 2 }, { id: 3 }] };
+    const after = { items: [{ id: 3 }, { id: 1 }, { id: 2 }] };
+    const changeset = diff(before, after, { embeddedObjKeys: { items: 'id' } });
+    expect(changeset[0].changes).toEqual(
+      expect.arrayContaining([
+        { type: Operation.MOVE, key: '3', from: 2, to: 0 },
+        { type: Operation.MOVE, key: '1', from: 0, to: 1 },
+        { type: Operation.MOVE, key: '2', from: 1, to: 2 }
+      ])
+    );
+
+    applyChangeset(before, changeset);
+    expect(before).toEqual(after);
+
+    revertChangeset(before, changeset);
+    expect(before).toEqual({ items: [{ id: 1 }, { id: 2 }, { id: 3 }] });
+  });
 });
 
 describe('jsonDiff#applyChangeset', () => {


### PR DESCRIPTION
## Summary
- add `MOVE` operation to track array reorders
- support applying and reverting moves when diffing arrays with embedded keys
- document and test move detection and handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68919e65757c8324b65e13247f2552b3