### PR TITLE
Update keyBy function to pass index to getKey callback

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -46,10 +46,10 @@ export function arrayIntersection<T>(first: T[], second: T[]): T[] {
     return first.filter(item => secondSet.has(item));
 }
 
-export function keyBy<T>(arr: T[], getKey: (item: T) => any): Record<string, T> {
+export function keyBy<T>(arr: T[], getKey: (item: T, index: number) => any): Record<string, T> {
     const result: Record<string, T> = {};
-    for (const item of arr) {
-        result[String(getKey(item))] = item;
+    for (const [index, item] of Object.entries(arr)) {
+        result[String(getKey(item, Number(index)))] = item;
     }
     return result;
 }

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -1,6 +1,6 @@
 import { arrayDifference as difference, arrayIntersection as intersection, keyBy, splitJSONPath } from './helpers.js';
 
-type FunctionKey = (obj: any, shouldReturnKeyName?: boolean) => any;
+type FunctionKey = (obj: any, index: number) => any;
 type EmbeddedObjKeysType = Record<string, string | FunctionKey>;
 type EmbeddedObjKeysMapType = Map<string | RegExp, string | FunctionKey>;
 enum Operation {


### PR DESCRIPTION
Hey,

I need to compose keys using a property value and the array index. So I updated `keyBy` to pass the index to the `getKey` callback. I removed `shouldReturnKeyName`, since it does not appear to be used and there was no clear way to keep it while adding the index.

If I missed any contribution rules, please let me know.

Greetings, Ruben