### PR TITLE
Fix null identity matching, string-based nested keys (v4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-diff-ts",
-  "version": "4.10.0",
+  "version": "4.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json-diff-ts",
-      "version": "4.10.0",
+      "version": "4.10.4",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-diff-ts",
-  "version": "4.10.3",
+  "version": "4.10.4",
   "description": "Modern TypeScript JSON diff library - Zero dependencies, high performance, ESM + CommonJS support. Calculate and apply differences between JSON objects with advanced features like key-based array diffing, JSONPath support, and atomic changesets.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -632,7 +632,7 @@ const convertArrayToObj = (arr: any[], uniqKey: any) => {
     const keyFunction = typeof uniqKey === 'string'
       ? (maybeNestedPath
           ? (item: any) => (item != null && typeof item === 'object' && uniqKey in item) ? item[uniqKey] : resolveProperty(item, uniqKey, true)
-          : (item: any) => item[uniqKey])
+          : (item: any) => item != null ? item[uniqKey] : undefined)
       : uniqKey;
     obj = keyBy(arr, keyFunction);
   }

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -572,12 +572,18 @@ const compareArray = (oldObj: any, newObj: any, path: any, keyPath: any, options
   const isFunctionKey = typeof uniqKey === 'function' && uniqKey.length === 2;
   if (diffs.length) {
     const resolvedKey = isFunctionKey ? uniqKey(newObj[0] ?? oldObj[0], true) : uniqKey;
+    // Nested path when resolvedKey contains '.' and matches NESTED_PATH_RE.
+    // Function keys qualify directly; string keys qualify only if the sample
+    // element does not expose resolvedKey as a literal property.
+    const sampleEl = newObj[0] ?? oldObj[0];
+    const isNestedPath = typeof resolvedKey === 'string' && resolvedKey.includes('.') && NESTED_PATH_RE.test(resolvedKey)
+      && (isFunctionKey || !(sampleEl != null && typeof sampleEl === 'object' && resolvedKey in sampleEl));
     return [
       {
         type: Operation.UPDATE,
         key: getKey(path),
         embeddedKey: resolvedKey,
-        ...(isFunctionKey && typeof resolvedKey === 'string' && NESTED_PATH_RE.test(resolvedKey) && resolvedKey.includes('.') ? { embeddedKeyIsPath: true } : {}),
+        ...(isNestedPath ? { embeddedKeyIsPath: true } : {}),
         changes: diffs
       }
     ];
@@ -622,8 +628,12 @@ const convertArrayToObj = (arr: any[], uniqKey: any) => {
       obj[i] = value;
     }
   } else {
-    // Convert string keys to functions for compatibility with es-toolkit keyBy
-    const keyFunction = typeof uniqKey === 'string' ? (item: any) => item[uniqKey] : uniqKey;
+    const maybeNestedPath = typeof uniqKey === 'string' && uniqKey.includes('.') && NESTED_PATH_RE.test(uniqKey);
+    const keyFunction = typeof uniqKey === 'string'
+      ? (maybeNestedPath
+          ? (item: any) => (item != null && typeof item === 'object' && uniqKey in item) ? item[uniqKey] : resolveProperty(item, uniqKey, true)
+          : (item: any) => item[uniqKey])
+      : uniqKey;
     obj = keyBy(arr, keyFunction);
   }
   return obj;
@@ -676,7 +686,7 @@ const indexOfItemInArray = (arr: any[], key: any, value: any, isPath?: boolean) 
     const item = arr[i];
     if (item == null) continue;
     const resolved = resolveProperty(item, key, isPath);
-    if (resolved != null && String(resolved) === String(value)) {
+    if (resolved !== undefined && String(resolved) === String(value)) {
       return i;
     }
   }
@@ -751,7 +761,7 @@ const applyArrayChange = (arr: any[], change: any) => {
       } else {
         element = arr.find((el) => {
           const resolved = resolveProperty(el, change.embeddedKey, change.embeddedKeyIsPath);
-          return resolved != null && String(resolved) === String(subchange.key);
+          return resolved !== undefined && String(resolved) === String(subchange.key);
         });
       }
       if (element) {
@@ -841,7 +851,7 @@ const revertArrayChange = (arr: any[], change: any) => {
       } else {
         element = arr.find((el) => {
           const resolved = resolveProperty(el, change.embeddedKey, change.embeddedKeyIsPath);
-          return resolved != null && String(resolved) === String(subchange.key);
+          return resolved !== undefined && String(resolved) === String(subchange.key);
         });
       }
       if (element) {

--- a/src/jsonDiff.ts
+++ b/src/jsonDiff.ts
@@ -575,9 +575,9 @@ const compareArray = (oldObj: any, newObj: any, path: any, keyPath: any, options
     // Nested path when resolvedKey contains '.' and matches NESTED_PATH_RE.
     // Function keys qualify directly; string keys qualify only if the sample
     // element does not expose resolvedKey as a literal property.
-    const sampleEl = newObj[0] ?? oldObj[0];
+    const sampleEl = [...newObj, ...oldObj].find((el) => el != null && typeof el === 'object');
     const isNestedPath = typeof resolvedKey === 'string' && resolvedKey.includes('.') && NESTED_PATH_RE.test(resolvedKey)
-      && (isFunctionKey || !(sampleEl != null && typeof sampleEl === 'object' && resolvedKey in sampleEl));
+      && (isFunctionKey || !(sampleEl != null && resolvedKey in sampleEl));
     return [
       {
         type: Operation.UPDATE,

--- a/tests/atomizeChangeset.test.ts
+++ b/tests/atomizeChangeset.test.ts
@@ -131,6 +131,67 @@ describe('atomizeChangeset', () => {
     expect(JSON.stringify(applied)).toEqual(JSON.stringify(newObj));
   });
 
+  test('when string-based nested identity key uses dot notation and round-trips', () => {
+    const oldObj = {
+      items: [
+        { positionNumber: { value: '001' }, description: 'alpha' },
+        { positionNumber: { value: '002' }, description: 'beta' },
+      ],
+    };
+    const newObj = {
+      items: [
+        { positionNumber: { value: '001' }, description: 'alpha' },
+        { positionNumber: { value: '002' }, description: 'updated' },
+      ],
+    };
+
+    const changes = diff(oldObj, newObj, {
+      embeddedObjKeys: { items: 'positionNumber.value' },
+    });
+    const atomic = atomizeChangeset(changes);
+    expect(atomic).toHaveLength(1);
+    expect(atomic[0].path).toBe("$.items[?(@.positionNumber.value=='002')].description");
+
+    // Apply round-trip
+    const applied = applyChangeset(JSON.parse(JSON.stringify(oldObj)), changes);
+    expect(JSON.stringify(applied)).toEqual(JSON.stringify(newObj));
+
+    // Atomize → unatomize → apply round-trip
+    const unatomized = unatomizeChangeset(atomic);
+    const appliedRoundTrip = applyChangeset(JSON.parse(JSON.stringify(oldObj)), unatomized);
+    expect(JSON.stringify(appliedRoundTrip)).toEqual(JSON.stringify(newObj));
+  });
+
+  test('when null identity value, apply and revert work correctly', () => {
+    const oldObj = {
+      items: [
+        { status: null, label: 'pending' },
+        { status: 'OK', label: 'done' },
+      ],
+    };
+    const newObj = {
+      items: [
+        { status: null, label: 'waiting' },
+        { status: 'OK', label: 'done' },
+      ],
+    };
+
+    const changes = diff(oldObj, newObj, {
+      embeddedObjKeys: { items: 'status' },
+    });
+
+    // Apply
+    const applied = applyChangeset(JSON.parse(JSON.stringify(oldObj)), changes);
+    expect(JSON.stringify(applied)).toEqual(JSON.stringify(newObj));
+
+    // Atomize → unatomize → apply round-trip
+    const atomic = atomizeChangeset(changes);
+    expect(atomic[0].path).toContain("status=='null'");
+    const unatomized = unatomizeChangeset(atomic);
+    const appliedRoundTrip = applyChangeset(JSON.parse(JSON.stringify(oldObj)), unatomized);
+    expect(JSON.stringify(appliedRoundTrip)).toEqual(JSON.stringify(newObj));
+  });
+
   test('when atomizing and unatomizing object properties', (done) => {
     const oldData: {
       planet: string;

--- a/tests/atomizeChangeset.test.ts
+++ b/tests/atomizeChangeset.test.ts
@@ -1,4 +1,4 @@
-import { diff, atomizeChangeset, applyChangeset, unatomizeChangeset, Operation } from '../src/jsonDiff';
+import { diff, atomizeChangeset, applyChangeset, revertChangeset, unatomizeChangeset, Operation } from '../src/jsonDiff';
 import type { FunctionKey } from '../src/helpers';
 
 describe('atomizeChangeset', () => {
@@ -183,6 +183,11 @@ describe('atomizeChangeset', () => {
     // Apply
     const applied = applyChangeset(JSON.parse(JSON.stringify(oldObj)), changes);
     expect(JSON.stringify(applied)).toEqual(JSON.stringify(newObj));
+
+    // Revert
+    const reverted = JSON.parse(JSON.stringify(newObj));
+    revertChangeset(reverted, changes);
+    expect(JSON.stringify(reverted)).toEqual(JSON.stringify(oldObj));
 
     // Atomize → unatomize → apply round-trip
     const atomic = atomizeChangeset(changes);


### PR DESCRIPTION
## Summary
Backport of fixes from #401 to v4:
- `indexOfItemInArray`/`applyArrayChange`/`revertArrayChange`: null identity values were never matched (`!= null` → `!== undefined`)
- `compareArray`: string keys with dots (e.g. `positionNumber.value`) now auto-detect nested vs literal based on data structure
- `convertArrayToObj`: resolves nested paths for string identity keys
- Guard `in` operator against primitives

## Test plan
- [x] All 107 v4 tests pass
- [x] Type check + lint clean

Version bump: 4.10.3 → 4.10.4